### PR TITLE
Refactor runCommand by extracting case methods

### DIFF
--- a/src/main/java/shibe/ItemList.java
+++ b/src/main/java/shibe/ItemList.java
@@ -96,35 +96,13 @@ public class ItemList {
         // Expected format for writing to file: command,,id,,name,,done,,optional
         switch (command) {
         case Todo.COMMAND:
-            Todo todoItem = Parser.parseToTodo(inputArray);
-            try {
-                writer.writeToFileNewLine(
-                        Arrays.asList("todo", todoItem.getId(), todoItem.getName(), String.valueOf(todoItem.isDone())));
-                return this.addItem(todoItem);
-            } catch (IOException e) {
-                return Ui.formatResponse("Could not write to file!");
-            }
+            return processTodoFromCommand(writer, inputArray);
 
         case Deadline.COMMAND:
-            Deadline deadlineItem = Parser.parseToDeadline(inputArray);
-            try {
-                writer.writeToFileNewLine(Arrays.asList("deadline", deadlineItem.getId(), deadlineItem.getName(),
-                        String.valueOf(deadlineItem.isDone()), deadlineItem.getDate().toString()));
-                return this.addItem(deadlineItem);
-            } catch (IOException e) {
-                return Ui.formatResponse("Could not write to file!");
-            }
+            return processDeadlineFromCommand(writer, inputArray);
 
         case Event.COMMAND:
-            Event eventItem = Parser.parseToEvent(inputArray);
-            try {
-                writer.writeToFileNewLine(Arrays.asList("event", eventItem.getId(), eventItem.getName(),
-                        String.valueOf(eventItem.isDone()), eventItem.getStartDate().toString(),
-                        eventItem.getEndDate().toString()));
-                return this.addItem(eventItem);
-            } catch (IOException e) {
-                return Ui.formatResponse("Could not write to file!");
-            }
+            return processEventFromCommand(writer, inputArray);
 
         case "list":
             return this.listItems();
@@ -143,6 +121,42 @@ public class ItemList {
 
         default:
             return Ui.formatResponse("No such command!");
+        }
+    }
+
+    public String processTodoFromCommand(Writer writer, String[] inputArray) throws MissingArgumentException {
+        Todo todoItem = Parser.parseToTodo(inputArray);
+        try {
+            writer.writeToFileNewLine(
+                    Arrays.asList("todo", todoItem.getId(), todoItem.getName(), String.valueOf(todoItem.isDone())));
+            return this.addItem(todoItem);
+        } catch (IOException e) {
+            return Ui.formatResponse("Could not write to file!");
+        }
+    }
+
+    public String processDeadlineFromCommand(Writer writer, String[] inputArray)
+            throws MissingArgumentException, InvalidArgumentException {
+        Deadline deadlineItem = Parser.parseToDeadline(inputArray);
+        try {
+            writer.writeToFileNewLine(Arrays.asList("deadline", deadlineItem.getId(), deadlineItem.getName(),
+                    String.valueOf(deadlineItem.isDone()), deadlineItem.getDate().toString()));
+            return this.addItem(deadlineItem);
+        } catch (IOException e) {
+            return Ui.formatResponse("Could not write to file!");
+        }
+    }
+
+    public String processEventFromCommand(Writer writer, String[] inputArray)
+            throws MissingArgumentException, InvalidArgumentException {
+        Event eventItem = Parser.parseToEvent(inputArray);
+        try {
+            writer.writeToFileNewLine(
+                    Arrays.asList("event", eventItem.getId(), eventItem.getName(), String.valueOf(eventItem.isDone()),
+                            eventItem.getStartDate().toString(), eventItem.getEndDate().toString()));
+            return this.addItem(eventItem);
+        } catch (IOException e) {
+            return Ui.formatResponse("Could not write to file!");
         }
     }
 


### PR DESCRIPTION
The runCommand method contained inline logic for handling Todo, Deadline, and Event commands, which made the method long and harder to maintain.

Let's extract the duplicated logic into separate methods: processTodoFromCommand
processDeadlineFromCommand
processEventFromCommand

This improves readability, reduces duplication, and makes future extensions easier.